### PR TITLE
Implemented fixes for inline time/memory annotations

### DIFF
--- a/skyline-vscode/src/decorations.ts
+++ b/skyline-vscode/src/decorations.ts
@@ -4,18 +4,20 @@ import * as vscode from 'vscode';
 
 export const simpleDecoration = vscode.window.createTextEditorDecorationType({
     isWholeLine: true,
-    borderWidth: '1px',
-    borderStyle: 'solid',
+    // borderWidth: '1px',
+    // borderStyle: 'solid',
     overviewRulerColor: 'blue',
     overviewRulerLane: vscode.OverviewRulerLane.Right,
     gutterIconPath: 'resources/right-arrow.png', 
     gutterIconSize: 'auto',
     light: {
         // this color will be used in light color themes
-        borderColor: 'darkblue'
+        borderColor: 'darkblue',
+        backgroundColor: new vscode.ThemeColor("merge.incomingContentBackground")
     },
     dark: {
         // this color will be used in dark color themes
-        borderColor: 'lightblue'
+        borderColor: 'lightblue',
+        backgroundColor: new vscode.ThemeColor("merge.incomingContentBackground")
     }
 });

--- a/skyline-vscode/src/extension.ts
+++ b/skyline-vscode/src/extension.ts
@@ -93,6 +93,11 @@ export function activate(context: vscode.ExtensionContext) {
 							sess = new SkylineSession(sess_options, environ_options);
 							sess.skylineProcess = skylineProcess;
 							sess.startSkyline = startSkyline;
+
+							vscode.window.onDidChangeActiveTextEditor(editor => {
+								console.log("onDidChangeActiveTextEditor");
+								if (editor) sess.annotate_editor(editor);
+							});
 						} else if (stderr.includes("An error occured during analysis")) {
 							console.log("Error, reporting to UI!");
 							sess.report_error(stderr);


### PR DESCRIPTION
Skyline provides inline annotations for the time/memory usage when a line of code is invoked. In the old implementation, we have the bug where these annotations disappear when the editor is refreshed. 

This commit fixes that issue, and also implements some visual changes (use background color instead of borders). 