### PR TITLE
Fix breakdown display granularity + double click to view source code

### DIFF
--- a/skyline-vscode/react-ui/src/MemoryPerfBar.js
+++ b/skyline-vscode/react-ui/src/MemoryPerfBar.js
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import PerfBar from './PerfBar';
+import App from './App';
 import {toReadableByteSize} from './utils';
 
 class MemoryPerfBar extends React.Component {
@@ -11,7 +12,7 @@ class MemoryPerfBar extends React.Component {
     super(props);
     // this._renderPerfHints = this._renderPerfHints.bind(this);
     // this._onClick = this._onClick.bind(this);
-    // this._onDoubleClick = this._onDoubleClick.bind(this);
+    this._onDoubleClick = this._onDoubleClick.bind(this);
     // this._onActiveChange = this._onActiveChange.bind(this);
   }
 
@@ -22,6 +23,16 @@ class MemoryPerfBar extends React.Component {
   //     `${overallPct.toFixed(2)}%`;
   // }
 
+  _onDoubleClick() {
+    let file_context = this.props.elem.file_refs[0];
+
+    App.vscodeApi.postMessage({
+      command: "highlight_source_line",
+      file: file_context.path,
+      lineno: file_context.line_no
+    });
+  }
+
   render() {
     // const {memoryNode, editorsByPath, ...rest} = this.props;
     const {tooltipHTML, ...rest} = this.props;
@@ -31,7 +42,7 @@ class MemoryPerfBar extends React.Component {
         renderPerfHints={()=>{}}
         tooltipHTML={tooltipHTML}
         // onClick={this._onClick}
-        // onDoubleClick={this._onDoubleClick}
+        onDoubleClick={this._onDoubleClick}
         // onActiveChange={this._onActiveChange}
         {...rest}
       />

--- a/skyline-vscode/src/skyline_session.ts
+++ b/skyline-vscode/src/skyline_session.ts
@@ -153,6 +153,14 @@ export class SkylineSession {
         } else if (msg['command'] == 'restart_profiling_clicked') {
 			vscode.window.showInformationMessage("Restarting profiling.");
             this.restart_profiling();
+        } else if (msg['command'] == "highlight_source_line") {
+            const openPath = vscode.Uri.file(path.join(this.root_dir, msg["file"]));
+            vscode.workspace.openTextDocument(openPath).then(doc => {
+                vscode.window.showTextDocument(doc).then(editor => {
+                    editor.revealRange(new vscode.Range(msg["lineno"], 0, msg["lineno"]+1, 0),
+                    vscode.TextEditorRevealType.InCenter)
+                });
+            });
         }
     }
 


### PR DESCRIPTION
As title suggests, this PR implements two changes:

1. The breakdown bar now displays things in the correct granularity. This was a problem for some models with a top-level module.
2. We can now double click on a segment of the breakdown bar to view the corresponding source code.