### PR TITLE
Display untracked operations in main UI

### DIFF
--- a/skyline-vscode/react-ui/src/App.js
+++ b/skyline-vscode/react-ui/src/App.js
@@ -77,8 +77,6 @@ function acquireApi() {
         } else {
             acquireApi.api = null;
         }
-    } else {
-        console.log("Api previously acquired. returning.");
     }
 
     return acquireApi.api;
@@ -127,8 +125,8 @@ function App() {
             let operation_tree = state.breakdown.operation_tree;
             let { coarse, fine } = getTraceByLevel(operation_tree);
             setTimeBreakdown({ 
-                coarse: computePercentage(coarse),
-                fine: computePercentage(fine)
+                coarse: computePercentage(coarse, state.breakdown.iteration_run_time_ms),
+                fine: computePercentage(fine, state.breakdown.iteration_run_time_ms)
             });
             ReactTooltip.rebuild();
         }
@@ -229,8 +227,8 @@ function App() {
                                         overallPct={elem["percentage"]}
                                         percentage={elem["percentage"]}
                                         resizable={false}
-                                        colorClass={"innpv-blue-color-" + ((idx % 5)+1)}
-                                        tooltipHTML={`<b>${elem["name"]}</b><br>Forward: ${Math.round(elem["forward_ms"]*100)/100}ms<br>Backward: ${Math.round(elem["backward_ms"]*100)/100}ms`}
+                                        colorClass={elem["name"] == "untracked" ?  "innpv-untracked-color" : "innpv-blue-color-" + ((idx % 5)+1)}
+                                        tooltipHTML={elem["name"] == "untracked" ? `<b>Untracked</b><br>Time: ${Math.round(elem["total_time"] * 100)/100}ms` : `<b>${elem["name"]}</b><br>Forward: ${Math.round(elem["forward_ms"]*100)/100}ms<br>Backward: ${Math.round(elem["backward_ms"]*100)/100}ms`}
                                     />
                                 }) : () => { return []; }
                             }}

--- a/skyline-vscode/react-ui/src/utils.js
+++ b/skyline-vscode/react-ui/src/utils.js
@@ -83,9 +83,24 @@ export function getTraceByLevel(tree) {
   }
 }
 
-export function computePercentage(operations) {
-  let total_time = 0;
-  for (let elem in operations) total_time += operations[elem]["forward_ms"] + operations[elem]["backward_ms"];
-  for (let elem in operations) operations[elem]["percentage"] = 100 * (operations[elem]["forward_ms"] + operations[elem]["backward_ms"]) / total_time;
+export function computePercentage(operations, total_time) {
+  let tracked_total_time = 0;
+  for (let elem in operations) {
+    tracked_total_time += operations[elem]["forward_ms"] + operations[elem]["backward_ms"];
+    operations[elem]["percentage"] = 100 * (operations[elem]["forward_ms"] + operations[elem]["backward_ms"]) / total_time;
+  }
+
+  if (tracked_total_time < total_time) {
+    operations.push({
+      name: "untracked",
+      percentage: 100 * (total_time - tracked_total_time) / total_time,
+      num_children: 0,
+      forward_ms: 0,
+      backward_ms: 0,
+      size_bytes: 0,
+      total_time: total_time - tracked_total_time
+    });
+  }
+
   return operations;
 }

--- a/skyline-vscode/src/extension.ts
+++ b/skyline-vscode/src/extension.ts
@@ -88,7 +88,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 					skylineProcess.stderr?.on('data', function(data) {
 						let stderr = data.toString();
-						console.log("stderr", stderr);
+						if (!stderr.includes("Missing kernel metadata entry"))
+							console.log("stderr", stderr);
 						if (stderr.includes("listening for connections")) {
 							console.log("Backend ready.");
 							sess = new SkylineSession(sess_options, environ_options);
@@ -109,7 +110,7 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 
 				startSkyline();
-				sess.startSkyline = startSkyline;
+				// sess.startSkyline = startSkyline;
 
 				skylineProcess.on("close", function() {
 				// on_close = function() {

--- a/skyline-vscode/src/extension.ts
+++ b/skyline-vscode/src/extension.ts
@@ -110,7 +110,6 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 
 				startSkyline();
-				// sess.startSkyline = startSkyline;
 
 				skylineProcess.on("close", function() {
 				// on_close = function() {


### PR DESCRIPTION
This PR adds the ability to visualize untracked times on the main UI. This helps to identify bottlenecks stemming from inefficient data loaders, etc. 

A visual demo of this is shown below (note the new bar element at the bottom): 
![image](https://user-images.githubusercontent.com/6977171/203406653-650ccf75-4a32-4ed8-98ee-8214210fd3af.png)
