### PR TITLE
Adjusted React build URIs

### DIFF
--- a/skyline-vscode/src/skyline_session.ts
+++ b/skyline-vscode/src/skyline_session.ts
@@ -305,11 +305,12 @@ export class SkylineSession {
 		const mainScript = manifest['files']['main.js'];
 		const mainStyle = manifest['files']['main.css'];
 
-		const scriptPathOnDisk = vscode.Uri.file(path.join(buildPath, 'build', mainScript));
-		const scriptUri = scriptPathOnDisk.with({ scheme: 'vscode-resource' });
-		const stylePathOnDisk = vscode.Uri.file(path.join(buildPath, 'build', mainStyle));
-		const styleUri = stylePathOnDisk.with({ scheme: 'vscode-resource' });
-
+        const buildPathOnDisk = vscode.Uri.file(path.join(buildPath, 'build'));
+        const buildUri = this.webviewPanel.webview.asWebviewUri(buildPathOnDisk);
+        const scriptPathOnDisk = vscode.Uri.file(path.join(buildPath, 'build', mainScript));
+        const scriptUri = this.webviewPanel.webview.asWebviewUri(scriptPathOnDisk);
+        const stylePathOnDisk = vscode.Uri.file(path.join(buildPath, 'build', mainStyle));
+        const styleUri = this.webviewPanel.webview.asWebviewUri(stylePathOnDisk);
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = crypto.randomBytes(16).toString('base64');
 
@@ -322,7 +323,7 @@ export class SkylineSession {
 				<title>Skyline</title>
 				<link rel="stylesheet" type="text/css" href="${styleUri}">
 				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https:; script-src 'nonce-${nonce}';style-src vscode-resource: 'unsafe-inline' http: https: data:;">
-				<base href="${vscode.Uri.file(path.join(buildPath, 'build')).with({ scheme: 'vscode-resource' })}/">
+				<base href="${ buildUri })}/">
 			</head>
 			<body>
 				<noscript>You need to enable JavaScript to run this app.</noscript>

--- a/skyline-vscode/src/skyline_session.ts
+++ b/skyline-vscode/src/skyline_session.ts
@@ -323,7 +323,7 @@ export class SkylineSession {
 				<title>Skyline</title>
 				<link rel="stylesheet" type="text/css" href="${styleUri}">
 				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https:; script-src 'nonce-${nonce}';style-src vscode-resource: 'unsafe-inline' http: https: data:;">
-				<base href="${ buildUri })}/">
+				<base href="${ buildUri }/">
 			</head>
 			<body>
 				<noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
John and I noticed that we were unable to use VSCode extension remotely. This was due to the fact that the URIs referencing the React build files were hard-coded to point to the local file directory.

To fix this, the React build URIs are transformed with `asWebviewUri`to get the corresponding URI for a user's system